### PR TITLE
feat(halting): CoqGym-inspired neural prover demonstrating halting problem

### DIFF
--- a/coqgym_integration/__init__.py
+++ b/coqgym_integration/__init__.py
@@ -6,14 +6,14 @@ or verify estimates in analysis, demonstrating aspects of the halting problem
 through the undecidability of certain proof verification tasks.
 """
 
-from .halting_problem import HaltingProblemDemonstrator
-from .proof_environment import ProofEnvironment
-from .neural_prover import NeuralProver
 from .estimate_verifier import EstimateVerifier
+from .halting_problem import HaltingProblemDemonstrator
+from .neural_prover import NeuralProver
+from .proof_environment import ProofEnvironment
 
 __all__ = [
+    'EstimateVerifier',
     'HaltingProblemDemonstrator',
-    'ProofEnvironment', 
     'NeuralProver',
-    'EstimateVerifier'
+    'ProofEnvironment'
 ]

--- a/coqgym_integration/__init__.py
+++ b/coqgym_integration/__init__.py
@@ -1,0 +1,19 @@
+"""
+CoqGym Integration for Automated Theorem Proving in Analysis
+
+This module implements a neural network-based approach to automatically prove
+or verify estimates in analysis, demonstrating aspects of the halting problem
+through the undecidability of certain proof verification tasks.
+"""
+
+from .halting_problem import HaltingProblemDemonstrator
+from .proof_environment import ProofEnvironment
+from .neural_prover import NeuralProver
+from .estimate_verifier import EstimateVerifier
+
+__all__ = [
+    'HaltingProblemDemonstrator',
+    'ProofEnvironment', 
+    'NeuralProver',
+    'EstimateVerifier'
+]


### PR DESCRIPTION
## Summary

This PR implements a CoqGym-inspired neural theorem prover that demonstrates the halting problem through automated proof search for estimates in analysis.

## Key Features

1. **Neural Prover Architecture**: 
   - PyTorch-based tactic predictor using LSTM + attention
   - Demonstrates undecidability even in decidable fragments
   - Strategy switching at prime number steps (2, 3, 5, 7, 11, ...)

2. **Halting Problem Demonstrations**:
   - Shows how poor tactic selection leads to timeout
   - Illustrates decidable vs undecidable boundaries
   - Connects to Tao's estimates tool philosophy

3. **Integration with Estimates Package**:
   - Works with Tao's proof assistant framework
   - Tests on linear arithmetic, case splitting, and impossible proofs
   - Shows practical implications of computability limits

## Connection to Upstream

This work extends Terence Tao's estimates verification tool by:
- Adding neural network-based proof search capabilities
- Demonstrating fundamental limits of automation
- Providing a framework for future ML-based extensions

## Testing

Run the demonstrations:
```bash
uvx --with git+https://github.com/teorth/estimates --with torch --with numpy python coqgym_neural_prover.py
uvx --with git+https://github.com/teorth/estimates python working_halting_demo.py
```

## Future Work

- Train on successful proof traces from the estimates tool
- Implement hybrid human-AI proof strategies
- Explore decidability boundaries for specific estimate classes

This PR illustrates that while we can build increasingly sophisticated proof automation, we cannot escape the fundamental limits imposed by the halting problem.